### PR TITLE
Implement Thomas algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +65,9 @@ dependencies = [
 [[package]]
 name = "comet-algorithms"
 version = "0.1.0"
+dependencies = [
+ "approx",
+]
 
 [[package]]
 name = "crunchy"

--- a/crates/comet-algorithms/Cargo.toml
+++ b/crates/comet-algorithms/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [lib]
 crate-type = ["lib"]
+
+[dev-dependencies]
+approx = "0.5.1"

--- a/crates/comet-algorithms/src/lib.rs
+++ b/crates/comet-algorithms/src/lib.rs
@@ -1,7 +1,9 @@
 mod boxplot;
 mod contour;
 mod histogram;
+mod linear_system;
 
 pub use boxplot::boxplot;
 pub use contour::contour;
 pub use histogram::histogram;
+pub use linear_system::thomas_algorithm;

--- a/crates/comet-algorithms/src/linear_system.rs
+++ b/crates/comet-algorithms/src/linear_system.rs
@@ -88,11 +88,6 @@ mod tests {
         let b = &[1.0, 42.0, 17.0, -5.0, 0.1];
 
         let x = thomas_algorithm(a, b);
-        assert!(<[f64]>::relative_eq(
-            &x,
-            b,
-            f64::EPSILON,
-            f64::EPSILON
-        ));
+        assert!(<[f64]>::relative_eq(&x, b, f64::EPSILON, f64::EPSILON));
     }
 }

--- a/crates/comet-algorithms/src/linear_system.rs
+++ b/crates/comet-algorithms/src/linear_system.rs
@@ -1,0 +1,98 @@
+/// Solve a system of linear equations A · x = b
+/// where A is a tridiagonal matrix.
+/// See https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm
+/// for more information.
+///
+/// Returns the solutions x of the system of linear equations.
+pub fn thomas_algorithm(a: &[&[f64]], b: &[f64]) -> Vec<f64> {
+    let n = b.len();
+
+    if n == 1 {
+        return vec![b[0] / a[0][0]];
+    }
+
+    let mut beta = vec![0.0; n];
+    let mut gamma = vec![0.0; n];
+    let mut y = vec![0.0; n];
+
+    beta[0] = a[0][0];
+    gamma[0] = a[0][1] / beta[0];
+    y[0] = b[0] / beta[0];
+
+    for i in 1..n {
+        let d_i = a[i][i];
+        let e_i = a[i][i - 1];
+        beta[i] = d_i - e_i * gamma[i - 1];
+
+        if i < n - 1 {
+            let c_i = a[i][i + 1];
+            gamma[i] = c_i / beta[i]
+        }
+
+        // backward elimination
+        y[i] = (b[i] - e_i * y[i - 1]) / beta[i];
+    }
+
+    let mut x = vec![0.0; n];
+    x[n - 1] = y[n - 1];
+
+    // forward elimination
+    for i in (0..=n - 2).rev() {
+        x[i] = y[i] - gamma[i] * x[i + 1];
+    }
+
+    x
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::thomas_algorithm;
+    use approx::RelativeEq;
+
+    #[test]
+    fn test_1x1() {
+        let a = &[[2.0].as_ref()];
+        let b = &[3.0];
+
+        let x = thomas_algorithm(a, b);
+        assert_eq!(x, vec![1.5]);
+    }
+
+    #[test]
+    fn test_3x3() {
+        let a = &[
+            [3.0, 2.0, 0.0].as_ref(),
+            [2.0, 4.0, 2.0].as_ref(),
+            [0.0, 2.0, 5.0].as_ref(),
+        ];
+        let b = &[1.0, 0.0, 3.0];
+
+        let x = thomas_algorithm(a, b);
+        assert!(<[f64]>::relative_eq(
+            &x,
+            &[1.0, -1.0, 1.0],
+            f64::EPSILON,
+            f64::EPSILON
+        ));
+    }
+
+    #[test]
+    fn text_5x5_identity() {
+        let a = &[
+            [1.0, 0.0, 0.0, 0.0, 0.0].as_ref(),
+            [0.0, 1.0, 0.0, 0.0, 0.0].as_ref(),
+            [0.0, 0.0, 1.0, 0.0, 0.0].as_ref(),
+            [0.0, 0.0, 0.0, 1.0, 0.0].as_ref(),
+            [0.0, 0.0, 0.0, 0.0, 1.0].as_ref(),
+        ];
+        let b = &[1.0, 42.0, 17.0, -5.0, 0.1];
+
+        let x = thomas_algorithm(a, b);
+        assert!(<[f64]>::relative_eq(
+            &x,
+            b,
+            f64::EPSILON,
+            f64::EPSILON
+        ));
+    }
+}

--- a/crates/comet/src/lib.rs
+++ b/crates/comet/src/lib.rs
@@ -266,13 +266,13 @@ pub fn thomas_algorithm(a: &[u8], b: &[u8]) -> Result<Vec<u8>, String> {
 
     let a = match decoder_a.pull().unwrap() {
         Header::Array(Some(len)) => read::read_float_array_2d(&mut decoder_a, len)?,
-        _ => return Err(String::from("input is not an array".to_string())),
+        _ => return Err("input is not an array".to_string()),
     };
     let a = a.iter().map(|r| r.as_slice()).collect::<Vec<&[f64]>>();
 
     let b = match decoder_b.pull().unwrap() {
         Header::Array(Some(len)) => read::read_float_array(&mut decoder_b, len)?,
-        _ => return Err(String::from("input is not an array".to_string())),
+        _ => return Err("input is not an array".to_string()),
     };
 
     let x = comet_algorithms::thomas_algorithm(&a, &b);

--- a/crates/comet/src/lib.rs
+++ b/crates/comet/src/lib.rs
@@ -17,22 +17,22 @@ pub fn contour(input: &[u8]) -> Result<Vec<u8>, String> {
             }
 
             let x = match decoder.pull().unwrap() {
-                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len),
+                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len)?,
                 _ => return Err(String::from("Bad input")),
             };
 
             let y = match decoder.pull().unwrap() {
-                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len),
+                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len)?,
                 _ => return Err(String::from("Bad input")),
             };
 
             let z = match decoder.pull().unwrap() {
-                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len),
+                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len)?,
                 _ => return Err(String::from("Bad input")),
             };
 
             let levels = match decoder.pull().unwrap() {
-                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len),
+                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len)?,
                 _ => return Err(String::from("Bad input")),
             };
 
@@ -77,12 +77,12 @@ pub fn histogram(input: &[u8]) -> Result<Vec<u8>, String> {
             }
 
             let values = match decoder.pull().unwrap() {
-                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len),
+                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len)?,
                 _ => return Err(String::from("Bad input")),
             };
 
             let edges = match decoder.pull().unwrap() {
-                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len),
+                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len)?,
                 Header::Positive(num_bins) => {
                     let min = values.iter().fold(f64::INFINITY, |a, &b| a.min(b));
                     let max = values.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b));
@@ -129,7 +129,7 @@ pub fn boxplot(input: &[u8]) -> Result<Vec<u8>, String> {
             }
 
             let values = match decoder.pull().unwrap() {
-                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len),
+                Header::Array(Some(len)) => read::read_float_array(&mut decoder, len)?,
                 _ => return Err(String::from("Bad input")),
             };
 
@@ -257,4 +257,36 @@ fn fft(input: &[u8]) -> Result<Vec<u8>, String> {
 #[wasm_func]
 fn ifft(input: &[u8]) -> Result<Vec<u8>, String> {
     fft_impl(input, FftDirection::Inverse)
+}
+
+#[wasm_func]
+pub fn thomas_algorithm(a: &[u8], b: &[u8]) -> Result<Vec<u8>, String> {
+    let mut decoder_a = Decoder::from(a);
+    let mut decoder_b = Decoder::from(b);
+
+    let a = match decoder_a.pull().unwrap() {
+        Header::Array(Some(len)) => read::read_float_array_2d(&mut decoder_a, len)?,
+        _ => return Err(String::from("input is not an array".to_string())),
+    };
+    let a = a.iter().map(|r| r.as_slice()).collect::<Vec<&[f64]>>();
+
+    let b = match decoder_b.pull().unwrap() {
+        Header::Array(Some(len)) => read::read_float_array(&mut decoder_b, len)?,
+        _ => return Err(String::from("input is not an array".to_string())),
+    };
+
+    let x = comet_algorithms::thomas_algorithm(&a, &b);
+
+    let mut output = Vec::new();
+    let mut encoder = Encoder::from(&mut output);
+
+    encoder.push(Header::Array(Some(x.len()))).unwrap();
+
+    for value in x {
+        encoder.push(Header::Float(value)).unwrap();
+    }
+
+    encoder.flush().unwrap();
+
+    Ok(output)
 }

--- a/crates/comet/src/read.rs
+++ b/crates/comet/src/read.rs
@@ -1,15 +1,36 @@
 use ciborium_ll::{Decoder, Header};
 use rustfft::num_complex::Complex64;
 
-pub fn read_float_array<R: std::io::Read>(decoder: &mut Decoder<R>, len: usize) -> Vec<f64> {
+pub fn read_float_array<R: std::io::Read>(
+    decoder: &mut Decoder<R>,
+    len: usize,
+) -> Result<Vec<f64>, String> {
     let mut values = Vec::<f64>::with_capacity(len);
     for _ in 0..len {
         match decoder.pull().unwrap() {
             Header::Float(x) => values.push(x),
-            _ => panic!("oof"),
+            header => return Err(format!("array element {:?} is not a float", header)),
         }
     }
-    values
+    Ok(values)
+}
+
+pub fn read_float_array_2d<R: std::io::Read>(
+    decoder: &mut Decoder<R>,
+    len: usize,
+) -> Result<Vec<Vec<f64>>, String> {
+    let mut values = Vec::with_capacity(len);
+
+    for _ in 0..len {
+        match decoder.pull().unwrap() {
+            Header::Array(Some(inner_len)) => {
+                values.push(read_float_array(decoder, inner_len)?);
+            }
+            header => return Err(format!("array element {:?} is not an array", header)),
+        }
+    }
+
+    Ok(values)
 }
 
 pub fn read_complex_array<R: std::io::Read>(

--- a/crates/comet/src/read.rs
+++ b/crates/comet/src/read.rs
@@ -9,7 +9,7 @@ pub fn read_float_array<R: std::io::Read>(
     for _ in 0..len {
         match decoder.pull().unwrap() {
             Header::Float(x) => values.push(x),
-            header => return Err(format!("array element {:?} is not a float", header)),
+            _ => return Err(String::from("array element is not a float")),
         }
     }
     Ok(values)
@@ -26,7 +26,7 @@ pub fn read_float_array_2d<R: std::io::Read>(
             Header::Array(Some(inner_len)) => {
                 values.push(read_float_array(decoder, inner_len)?);
             }
-            header => return Err(format!("array element {:?} is not an array", header)),
+            _ => return Err(String::from("array element is not an array")),
         }
     }
 

--- a/src/assertations.typ
+++ b/src/assertations.typ
@@ -1,0 +1,34 @@
+/// Assert that two floats or arrays are equal up to a (configurable) epsilon.
+#let approx(
+
+  /// First value.
+  a,
+
+  /// Second value.
+  b,
+
+  /// Absolute tolerance.
+  eps: 1e-20,
+
+  // Relative tolerance
+  rel-eps: 1e-09
+
+) = {
+  if type(a) == array and type(b) == array {
+    assert(a.len() == b.len(), message: "Non-matching array lengths " + repr(a) + " / " + repr(b))
+    for (x, y) in a.zip(b) {
+      // if calc.abs(x - y) >= eps and calc.abs(1 - calc.abs(x / y)) >= eps {
+      if calc.abs(x - y) > calc.max(rel-eps * calc.max(calc.abs(x), calc.abs(y)), eps) {
+        assert(false, message: repr(x) + " was not approx equal to " + repr(y) )
+        assert(false, message: repr(a) + " was not approx equal to " + repr(b) )
+      }
+    }
+  } else {
+    assert(calc.abs(a - b) < eps, message: str(a) + " and " + str(b) + " are not equal up to " + str(eps))
+
+  }
+}
+
+
+#approx(1, 1)
+#approx((5e45, 1e46, 1.4999999999999999e46, 2e46), (5e45, 1e46, 1.5e46, 2e46))

--- a/src/comet.typ
+++ b/src/comet.typ
@@ -2,3 +2,4 @@
 #import "contour.typ": contour
 #import "histogram.typ": histogram
 #import "boxplot.typ": boxplot
+#import "linear_system.typ": thomas-algorithm

--- a/src/linear_system.typ
+++ b/src/linear_system.typ
@@ -1,0 +1,27 @@
+#import "plugin.typ": comet-plugin
+
+/// Solve a system of linear equations $A dot arrow(x) = arrow(b)$
+/// where $A$ is a tridiagonal matrix.
+/// See https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm
+/// for more information.
+///
+/// Returns the solutions $arrow(x) in RR^n$ of the system of linear equqations.
+///
+/// -> array
+#let thomas-algorithm(
+  /// The matrix $A in RR^(n times n)$ of the system of linear equations.
+  /// The data format is an array of arrays, in row-major order.
+  ///
+  /// -> array
+  A,
+  /// The vector $arrow(b) in RR^n$ of the system of linear equations.
+  ///
+  /// -> array
+  b,
+) = {
+  let A = cbor.encode(A.map(row => row.map(float)))
+  let b = cbor.encode(b.map(float))
+
+  cbor(comet-plugin.thomas_algorithm(A, b))
+}
+

--- a/src/linear_system.typ
+++ b/src/linear_system.typ
@@ -5,7 +5,9 @@
 /// See https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm
 /// for more information.
 ///
-/// Returns the solutions $arrow(x) in RR^n$ of the system of linear equqations.
+/// Panics if there's a mismatch in the matrix or vector dimensions.
+///
+/// Returns the solutions $arrow(x) in RR^n$ of the system of linear equations.
 ///
 /// -> array
 #let thomas-algorithm(
@@ -19,6 +21,13 @@
   /// -> array
   b,
 ) = {
+  let n = A.len()
+
+  for row in A {
+    assert.eq(row.len(), n, message: "matrix is not square")
+  }
+  assert.eq(b.len(), n, message: "vector dimension does not match matrix dimension")
+
   let A = cbor.encode(A.map(row => row.map(float)))
   let b = cbor.encode(b.map(float))
 

--- a/tests/linear_system/test.typ
+++ b/tests/linear_system/test.typ
@@ -18,3 +18,36 @@
 #let b = (1, 42, 17, -5, 0.1)
 #let x = thomas-algorithm(A, b)
 #approx(x, b)
+
+#let A = ((3, 2), (2, 4), (0, 2, 5))
+#let b = (1, 0, 3)
+#assert.eq(
+  catch(
+    () => {
+      thomas-algorithm(A, b)
+    },
+  ),
+  "equality assertion failed: matrix is not square",
+)
+
+#let A = ((3, 2, 0), (2, 4))
+#let b = (1, 0, 3)
+#assert.eq(
+  catch(
+    () => {
+      thomas-algorithm(A, b)
+    },
+  ),
+  "equality assertion failed: matrix is not square",
+)
+
+#let A = ((3, 2, 0), (2, 4, 2), (0, 2, 5))
+#let b = (1, 0)
+#assert.eq(
+  catch(
+    () => {
+      thomas-algorithm(A, b)
+    },
+  ),
+  "equality assertion failed: vector dimension does not match matrix dimension",
+)

--- a/tests/linear_system/test.typ
+++ b/tests/linear_system/test.typ
@@ -1,0 +1,20 @@
+#import "/src/comet.typ": thomas-algorithm
+#import "/src/assertations.typ": approx
+
+#let A = ((2,),)
+#let b = (3,)
+#let x = thomas-algorithm(A, b)
+#assert.eq(x, (1.5,))
+
+#let A = ((3, 2, 0), (2, 4, 2), (0, 2, 5))
+#let b = (1, 0, 3)
+#let x = thomas-algorithm(A, b)
+#approx(x, (1, -1, 1))
+
+#let A = ((0,) * 5,) * 5
+#for i in range(0, 5) {
+  A.at(i).at(i) = 1
+}
+#let b = (1, 42, 17, -5, 0.1)
+#let x = thomas-algorithm(A, b)
+#approx(x, b)


### PR DESCRIPTION
As mentioned in https://github.com/lilaq-project/lilaq/pull/68#issuecomment-3078702160, this MR ports the Thomas algorithm for solving tridiagonal linear systems of equations (used for plot smoothing).

Apart from implementing the algorithm itself, I also modified `read_float_array` to return an error instead of panicking.
When the plugin panics the panic message is not displayed, which makes it difficult to debug.

I haven't ported the `bezier-interpolation` code, because I wasn't sure how much of the typst code you want to replace with Rust.